### PR TITLE
Fixed the usage section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add these lines to your `.emacs` file:
 
 ```
 (require 'bool-flip)
-(global-set-key (kbd "C-c b") bool-flip-do-flip)
+(global-set-key (kbd "C-c b") 'bool-flip-do-flip)
 ```
 
 ## Changelog


### PR DESCRIPTION
Addresses [this issue](https://github.com/michaeljb/bool-flip/issues/3); the code in the Usage section was incorrect because an apostrophe was needed before `bool-flip-do-flip`. 